### PR TITLE
fix pypi issue

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = R0913, R0914, C0415, E0402
+max-line-length = 88
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,6 @@ jobs:
           env_vars: OS,PYTHON
           name: codecov-umbrella
           fail_ci_if_error: false
-#      - name: Analysing the code with pylint
-#        shell: bash -l {0}
-#        run: |
-#          pylint $(git ls-files '*.py') --fail-under=9.5 --ignore-paths=doc,gcmt/tests --disable=R0913,R0914,C0415,E0402
 
   xarray-master:
     name: Build xarray-master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 #      - name: Analysing the code with pylint
 #        shell: bash -l {0}
 #        run: |
-#          pylint $(git ls-files '*.py') --fail-under=9.5 --ignore-paths=doc,gcmt/tests --disable=R0913,R0914,C0415
+#          pylint $(git ls-files '*.py') --fail-under=9.5 --ignore-paths=doc,gcmt/tests --disable=R0913,R0914,C0415,E0402
 
   xarray-master:
     name: Build xarray-master

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,10 +18,6 @@ jobs:
       run: |
         python -m pip install -e .
         pip install pylint
-#        pip install matplotlib
-#        pip install cubedsphere==0.2
-#        pip install xgcm
-#        pip install prt_phasecurve
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py') --fail-under=9.5 --ignore-paths=doc,gcmt/tests --disable=R0913,R0914,C0415,E0402
+        pylint $(git ls-files '*.py') --fail-under=9.5 --ignore-paths=doc,gcmt/tests --disable=R0913,R0914,C0415,E0401,E0402

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -24,4 +24,4 @@ jobs:
 #        pip install prt_phasecurve
 #    - name: Analysing the code with pylint
 #      run: |
-#        pylint $(git ls-files '*.py') --fail-under=9.5 --ignore-paths=doc,gcmt/tests --disable=R0913,R0914,C0415
+#        pylint $(git ls-files '*.py') --fail-under=9.5 --ignore-paths=doc,gcmt/tests --disable=R0913,R0914,C0415,E0402

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,14 +14,14 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-#    - name: Install dependencies
-#      run: |
-#        python -m pip install -e .
-#        pip install pylint
+    - name: Install dependencies
+      run: |
+        python -m pip install -e .
+        pip install pylint
 #        pip install matplotlib
 #        pip install cubedsphere==0.2
 #        pip install xgcm
 #        pip install prt_phasecurve
-#    - name: Analysing the code with pylint
-#      run: |
-#        pylint $(git ls-files '*.py') --fail-under=9.5 --ignore-paths=doc,gcmt/tests --disable=R0913,R0914,C0415,E0402
+    - name: Analysing the code with pylint
+      run: |
+        pylint $(git ls-files '*.py') --fail-under=9.5 --ignore-paths=doc,gcmt/tests --disable=R0913,R0914,C0415,E0402

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+    - id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+    - id: flake8

--- a/ci/environment-3.10.yml
+++ b/ci/environment-3.10.yml
@@ -11,5 +11,5 @@ dependencies:
   - pip:
       - git+https://github.com/MITgcm/xmitgcm.git
       - git+https://github.com/pydata/xarray.git
-      - pylint==2.14.5
-      - astroid==2.11.7
+      - pylint
+      - astroid

--- a/ci/environment-3.10.yml
+++ b/ci/environment-3.10.yml
@@ -7,7 +7,7 @@ dependencies:
   - pytest
   - codecov
   - pytest-cov
+  - xarray
   - pip
   - pip:
       - git+https://github.com/MITgcm/xmitgcm.git
-      - git+https://github.com/pydata/xarray.git

--- a/ci/environment-3.10.yml
+++ b/ci/environment-3.10.yml
@@ -11,5 +11,3 @@ dependencies:
   - pip:
       - git+https://github.com/MITgcm/xmitgcm.git
       - git+https://github.com/pydata/xarray.git
-      - pylint
-      - astroid

--- a/ci/environment-3.8.yml
+++ b/ci/environment-3.8.yml
@@ -11,6 +11,3 @@ dependencies:
   - pip:
       - git+https://github.com/MITgcm/xmitgcm.git
       - git+https://github.com/pydata/xarray.git
-      - pylint
-      - astroid
-

--- a/ci/environment-3.8.yml
+++ b/ci/environment-3.8.yml
@@ -7,7 +7,7 @@ dependencies:
   - pytest
   - codecov
   - pytest-cov
+  - xarray
   - pip
   - pip:
       - git+https://github.com/MITgcm/xmitgcm.git
-      - git+https://github.com/pydata/xarray.git

--- a/ci/environment-3.8.yml
+++ b/ci/environment-3.8.yml
@@ -11,6 +11,6 @@ dependencies:
   - pip:
       - git+https://github.com/MITgcm/xmitgcm.git
       - git+https://github.com/pydata/xarray.git
-      - pylint==2.14.5
-      - astroid==2.11.7
+      - pylint
+      - astroid
 

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -11,5 +11,5 @@ dependencies:
   - pip:
       - git+https://github.com/MITgcm/xmitgcm.git
       - git+https://github.com/pydata/xarray.git
-      - pylint==2.14.5
-      - astroid==2.11.7
+      - pylint
+      - astroid

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -7,7 +7,7 @@ dependencies:
   - pytest
   - codecov
   - pytest-cov
+  - xarray
   - pip
   - pip:
       - git+https://github.com/MITgcm/xmitgcm.git
-      - git+https://github.com/pydata/xarray.git

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -11,5 +11,3 @@ dependencies:
   - pip:
       - git+https://github.com/MITgcm/xmitgcm.git
       - git+https://github.com/pydata/xarray.git
-      - pylint
-      - astroid

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -37,3 +37,12 @@ Install ``gcmt``.
 
         git clone https://github.com/exorad/gcmt.git
         pip install -e gcmt
+
+    We recommend to install ``pre-commit`` into your git hooks.
+    This will automatically format the code to meet common style guidelines.
+    Its as easy as:
+
+    .. code-block:: bash
+
+        cd gcmt
+        pre-commit install

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -63,7 +63,7 @@ Interface
 ``gcmt`` comes with some interfaces to other codes.
 We currently have support for ``petitRADTRANS`` to calculate spectra and phasecurves with ``prt_phasecure``.
 
-.. autoclass:: gcmt.utils.interface.pRTInterface
+.. autoclass:: gcmt.utils.interface.PrtInterface
     :members: __init__, set_data, chem_from_poorman, calc_phase_spectrum, phase_curve
 
 

--- a/gcmt/core/units.py
+++ b/gcmt/core/units.py
@@ -8,7 +8,7 @@
 import astropy.units as u
 import numpy as np
 
-from gcmt.core.const import VARNAMES as c
+from .const import VARNAMES as c
 
 ALLOWED_PUNITS = ['bar', 'Pa']
 ALLOWED_TIMEUNITS = ['day', 'iter']

--- a/gcmt/exorad/read_in.py
+++ b/gcmt/exorad/read_in.py
@@ -15,18 +15,18 @@ import os
 
 import xarray as xr
 
-import gcmt.core.writer as wrt
-from gcmt.core.units import convert_pressure, convert_time
+from ..core import writer as wrt
+from ..core.units import convert_pressure, convert_time
 
 
-def m_read_from_mitgcm(gcmt, data_path, iters, exclude_iters=None, d_lon=5, d_lat=4,
+def m_read_from_mitgcm(tools, data_path, iters, exclude_iters=None, d_lon=5, d_lat=4,
                        loaded_dsi=None, **kwargs):
     """
     Data read in for MITgcm output.
 
     Parameters
     ----------
-    gcmt : GCMT
+    tools : GCMT
         GCMTools to which the data should be added
     data_path : str
         Folder path to the standard output of the GCM.
@@ -91,8 +91,8 @@ def m_read_from_mitgcm(gcmt, data_path, iters, exclude_iters=None, d_lon=5, d_la
     # convert wind, vertical dimension, time, ...
     dsi = exorad_postprocessing(dsi, outdir=data_path)
 
-    convert_pressure(dsi, current_unit='Pa', goal_unit=gcmt.p_unit)
-    convert_time(dsi, current_unit='iter', goal_unit=gcmt.time_unit)
+    convert_pressure(dsi, current_unit='Pa', goal_unit=tools.p_unit)
+    convert_time(dsi, current_unit='iter', goal_unit=tools.time_unit)
 
     if loaded_dsi is not None:
         dsi = xr.merge([dsi, loaded_dsi])

--- a/gcmt/gcm_dataset_collection.py
+++ b/gcmt/gcm_dataset_collection.py
@@ -1,6 +1,6 @@
 """ GCM dataset collection class to deal with GCM data """
 from collections import UserDict
-import gcmt.core.writer as wrt
+from .core import writer as wrt
 
 
 class GCMDatasetCollection(UserDict):

--- a/gcmt/gcmtools.py
+++ b/gcmt/gcmtools.py
@@ -10,14 +10,14 @@
 """
 import xarray
 
-import gcmt.core.writer as wrt
-import gcmt.utils.gcm_plotting as gcmplt
-import gcmt.utils.manipulations as mani
-import gcmt.utils.read_and_write as raw
-from gcmt.gcm_dataset_collection import GCMDatasetCollection
-from gcmt.core.units import ALLOWED_PUNITS, ALLOWED_TIMEUNITS
-from gcmt.utils.passport import is_the_data_basic
-from gcmt.utils.interface import  PrtInterface
+from .core import writer as wrt
+from .utils import gcm_plotting as gcmplt
+from .utils import manipulations as mani
+from .utils import read_and_write as raw
+from .gcm_dataset_collection import GCMDatasetCollection
+from .core.units import ALLOWED_PUNITS, ALLOWED_TIMEUNITS
+from .utils.passport import is_the_data_basic
+from .utils.interface import PrtInterface
 
 
 class GCMT:

--- a/gcmt/utils/gcm_plotting.py
+++ b/gcmt/utils/gcm_plotting.py
@@ -11,8 +11,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.collections import LineCollection
 
-import gcmt.core.writer as wrt
-from gcmt.core.const import VARNAMES as c
+from ..core import writer as wrt
+from ..core.const import VARNAMES as c
 
 # pylint: disable=R0915,R0912
 def isobaric_slice(dsi, var_key, pres, time=-1, lookup_method='exact', axs=None,

--- a/gcmt/utils/interface.py
+++ b/gcmt/utils/interface.py
@@ -14,7 +14,7 @@
 import numpy as np
 import xarray as xr
 
-from gcmt.core.const import VARNAMES as c
+from ..core.const import VARNAMES as c
 
 
 class _Chemistry:
@@ -143,15 +143,15 @@ class Interface:
     chem_from_poorman: Function that calculates chemistry based on the poorman code from pRT
     """
 
-    def __init__(self, gcmt):
+    def __init__(self, tools):
         """
         Constructor for the Interface class
 
         Parameters
         ----------
-        gcmt: GCMTools Object
+        tools: GCMTools Object
         """
-        self.gcmt = gcmt
+        self.tools = tools
         self.chemistry = _Chemistry()
         self.dsi = None
 
@@ -183,7 +183,7 @@ class Interface:
         regrid_lowres: bool, optional
             Can be useful, if your GCMT uses a very detailed grid
         """
-        dsi = self.gcmt.get_one_model(tag).sel(time=time)
+        dsi = self.tools.get_one_model(tag).sel(time=time)
 
         if regrid_lowres:
             dlon = 15
@@ -226,18 +226,18 @@ class PrtInterface(Interface):
     Interface with petitRADTRANS
     """
 
-    def __init__(self, gcmt, prt):
+    def __init__(self, tools, prt):
         """
         Constructs the Interface and links to pRT.
 
         Parameters
         ----------
-        gcmt: GCMTools Object
+        tools: GCMTools Object
             A GCMTools object that is linked to the interface
         pRT: petitRADTRANS.Radtrans
             A pRT Radtrans object
         """
-        super().__init__(gcmt)
+        super().__init__(tools)
         self.prt = prt
 
     def set_data(self, time, tag=None, regrid_lowres=False):

--- a/gcmt/utils/manipulations.py
+++ b/gcmt/utils/manipulations.py
@@ -2,8 +2,8 @@
 Functions to manipulate GCM data
 """
 import numpy as np
-import gcmt.core.writer as wrt
-from gcmt.core.const import VARNAMES as c
+from ..core import writer as wrt
+from ..core.const import VARNAMES as c
 
 
 def m_add_horizontal_average(dsi, var_key, var_key_out=None, area_key='area_c'):

--- a/gcmt/utils/passport.py
+++ b/gcmt/utils/passport.py
@@ -9,8 +9,8 @@
  value error if the conditions are not fulfilled.
 ==============================================================
 """
-import gcmt.core.writer as wrt
-from gcmt.core.const import VARNAMES as c
+from ..core import writer as wrt
+from ..core.const import VARNAMES as c
 
 
 def is_the_data_basic(dataset):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+# Example configuration for Black.
+
+# NOTE: you have to use single-quoted strings in TOML for regular expressions.
+# It's the equivalent of r-strings in Python.  Multiline strings are treated as
+# verbose regular expressions by Black.  Use [ ] to denote a significant space
+# character.
+
+[tool.black]
+line-length = 88
+include = '\.pyi?$'
+target-version = ['py38', 'py39', 'py310']
+# We use preview style for formatting Black itself. If you
+# want stable formatting across releases, you should keep
+# this off.
+preview = true
+
+# Build system information below.
+# NOTE: You don't need this in your own Black configuration.
+
+[build-system]
+requires = ["setuptools>=45.0", "setuptools_scm[toml]>=6.3.1", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+# Option below requires `tests/optional.py`
+addopts = "--strict-config --strict-markers"
+optional-tests = [
+  "no_blackd: run when `d` extra NOT installed",
+  "no_jupyter: run when `jupyter` extra NOT installed",
+]
+markers = [
+  "incompatible_with_mypyc: run when testing mypyc compiled black"
+]
+xfail_strict = true
+filterwarnings = [
+    "error",
+    # this is mitigated by a try/catch in https://github.com/psf/black/pull/2974/
+    # this ignore can be removed when support for aiohttp 3.7 is dropped.
+    '''ignore:Decorator `@unittest_run_loop` is no longer needed in aiohttp 3\.8\+:DeprecationWarning''',
+    # this is mitigated by https://github.com/python/cpython/issues/79071 in python 3.8+
+    # this ignore can be removed when support for 3.7 is dropped.
+    '''ignore:Bare functions are deprecated, use async ones:DeprecationWarning''',
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,31 +13,3 @@ target-version = ['py38', 'py39', 'py310']
 # want stable formatting across releases, you should keep
 # this off.
 preview = true
-
-# Build system information below.
-# NOTE: You don't need this in your own Black configuration.
-
-[build-system]
-requires = ["setuptools>=45.0", "setuptools_scm[toml]>=6.3.1", "wheel"]
-build-backend = "setuptools.build_meta"
-
-[tool.pytest.ini_options]
-# Option below requires `tests/optional.py`
-addopts = "--strict-config --strict-markers"
-optional-tests = [
-  "no_blackd: run when `d` extra NOT installed",
-  "no_jupyter: run when `jupyter` extra NOT installed",
-]
-markers = [
-  "incompatible_with_mypyc: run when testing mypyc compiled black"
-]
-xfail_strict = true
-filterwarnings = [
-    "error",
-    # this is mitigated by a try/catch in https://github.com/psf/black/pull/2974/
-    # this ignore can be removed when support for aiohttp 3.7 is dropped.
-    '''ignore:Decorator `@unittest_run_loop` is no longer needed in aiohttp 3\.8\+:DeprecationWarning''',
-    # this is mitigated by https://github.com/python/cpython/issues/79071 in python 3.8+
-    # this ignore can be removed when support for 3.7 is dropped.
-    '''ignore:Bare functions are deprecated, use async ones:DeprecationWarning''',
-]

--- a/setup.py
+++ b/setup.py
@@ -2,31 +2,32 @@
 from setuptools import setup, find_packages
 
 
-with open("README.md", "r", encoding='utf-8') as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-SETUP_REQUIRES = ['pytest-runner']
-TESTS_REQUIRE = ['pytest >= 4.0', 'coverage']
+SETUP_REQUIRES = ["pytest-runner"]
+TESTS_REQUIRE = ["pytest >= 4.0", "coverage"]
 INSTALL_REQUIRES = [
-        "scipy>=1.7.0",
-        "numpy",
-        "f90nml",
-        "astropy",
-        "xarray",
-        "pyyaml"
-    ]
+    "scipy>=1.7.0",
+    "numpy",
+    "f90nml",
+    "astropy",
+    "xarray",
+    "pyyaml",
+    "pre-commit",
+]
 
 setup(
-    name='gcmt',
-    version='v0.1.4',
+    name="gcmt",
+    version="v0.1.4",
     packages=find_packages(),
     include_package_data=True,
-    scripts=['bin/convert_to_gcmt'],
-    url='https://github.com/exorad/gcmt',
-    license='MIT',
-    author='Aaron David Schneider',
-    author_email='aarondavid.schneider@nbi.ku.dk',
-    description='postprocessing stuff',
+    scripts=["bin/convert_to_gcmt"],
+    url="https://github.com/exorad/gcmt",
+    license="MIT",
+    author="Aaron David Schneider",
+    author_email="aarondavid.schneider@nbi.ku.dk",
+    description="postprocessing stuff",
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=INSTALL_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ INSTALL_REQUIRES = [
 
 setup(
     name='gcmt',
-    version='v0.1.3',
+    version='v0.1.4',
     packages=find_packages(),
     include_package_data=True,
     scripts=['bin/convert_to_gcmt'],


### PR DESCRIPTION
This PR fixes pypi issues (#31 ) by reintroducing relative imports.

The current code uses absolute package imports which fails, when installing `gcmt` via
```
pip install gcmt
```

This PR fixes this.

Closes #31
Closes #28
Closes #30

@Kiefersv, please check and merge when you think that everything is fine.